### PR TITLE
Implement double Ctrl+C to exit

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -45,7 +45,7 @@ import { createInputItem } from "./utils/input-utils";
 import { initLogger } from "./utils/logger/log";
 import { isModelSupportedForResponses } from "./utils/model-utils.js";
 import { parseToolCall } from "./utils/parsers";
-import { onExit, setInkRenderer } from "./utils/terminal";
+import { onExit, setInkRenderer, confirmExit } from "./utils/terminal";
 import chalk from "chalk";
 import { spawnSync } from "child_process";
 import fs from "fs";
@@ -689,9 +689,15 @@ const exit = () => {
   process.exit(0);
 };
 
-process.on("SIGINT", exit);
-process.on("SIGQUIT", exit);
-process.on("SIGTERM", exit);
+const handleCtrlC = () => {
+  if (confirmExit()) {
+    exit();
+  }
+};
+
+process.on("SIGINT", handleCtrlC);
+process.on("SIGQUIT", handleCtrlC);
+process.on("SIGTERM", handleCtrlC);
 
 // ---------------------------------------------------------------------------
 // Fallback for Ctrl-C when stdin is in raw-mode
@@ -705,7 +711,7 @@ if (process.stdin.isTTY) {
   const onRawData = (data: Buffer | string): void => {
     const str = Buffer.isBuffer(data) ? data.toString("utf8") : data;
     if (str === "\u0003") {
-      exit();
+      handleCtrlC();
     }
   };
   process.stdin.on("data", onRawData);

--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -21,7 +21,7 @@ import {
   loadCommandHistory,
   addToHistory,
 } from "../../utils/storage/command-history.js";
-import { clearTerminal, onExit } from "../../utils/terminal.js";
+import { clearTerminal, onExit, confirmExit } from "../../utils/terminal.js";
 import { Box, Text, useApp, useInput, useStdin } from "ink";
 import { fileURLToPath } from "node:url";
 import React, {
@@ -110,6 +110,7 @@ export default function TerminalChatInput({
   // Track the caret row across keystrokes
   const prevCursorRow = useRef<number | null>(null);
   const prevCursorWasAtLastRow = useRef<boolean>(false);
+  const [awaitingExit, setAwaitingExit] = useState(false);
 
   // --- Helper for updating input, remounting editor, and moving cursor to end ---
   const applyFsSuggestion = useCallback((newInputText: string) => {
@@ -457,11 +458,16 @@ export default function TerminalChatInput({
           ]);
         }
       } else if (_input === "\u0003" || (_input === "c" && _key.ctrl)) {
-        setTimeout(() => {
-          app.exit();
-          onExit();
-          process.exit(0);
-        }, 60);
+        if (confirmExit()) {
+          setTimeout(() => {
+            app.exit();
+            onExit();
+            process.exit(0);
+          }, 60);
+        } else {
+          setAwaitingExit(true);
+          setTimeout(() => setAwaitingExit(false), 1500);
+        }
       }
     },
     { isActive: active },
@@ -853,26 +859,29 @@ export default function TerminalChatInput({
             displayLimit={5}
           />
         ) : (
-          <Text dimColor>
-            ctrl+c to exit | "/" to see commands | enter to send
-            {contextLeftPercent > 25 && (
-              <>
-                {" — "}
-                <Text color={contextLeftPercent > 40 ? "green" : "yellow"}>
-                  {Math.round(contextLeftPercent)}% context left
-                </Text>
-              </>
-            )}
-            {contextLeftPercent <= 25 && (
-              <>
-                {" — "}
-                <Text color="red">
-                  {Math.round(contextLeftPercent)}% context left — send
-                  "/compact" to condense context
-                </Text>
-              </>
-            )}
-          </Text>
+          <>
+            <Text dimColor>
+              ctrl+c twice to exit | "/" to see commands | enter to send
+              {contextLeftPercent > 25 && (
+                <>
+                  {" — "}
+                  <Text color={contextLeftPercent > 40 ? "green" : "yellow"}>
+                    {Math.round(contextLeftPercent)}% context left
+                  </Text>
+                </>
+              )}
+              {contextLeftPercent <= 25 && (
+                <>
+                  {" — "}
+                  <Text color="red">
+                    {Math.round(contextLeftPercent)}% context left — send
+                    "/compact" to condense context
+                  </Text>
+                </>
+              )}
+            </Text>
+            {awaitingExit && <Text dimColor>Press Ctrl+C again to exit</Text>}
+          </>
         )}
       </Box>
     </Box>

--- a/codex-cli/src/components/singlepass-cli-app.tsx
+++ b/codex-cli/src/components/singlepass-cli-app.tsx
@@ -17,6 +17,7 @@ import {
   makeAsciiDirectoryStructure,
 } from "../utils/singlepass/context_files";
 import { EditedFilesSchema } from "../utils/singlepass/file_ops";
+import { confirmExit } from "../utils/terminal";
 import * as fsSync from "fs";
 import * as fsPromises from "fs/promises";
 import { Box, Text, useApp, useInput } from "ink";
@@ -215,11 +216,12 @@ function InputPrompt({
 
   useInput((input, key) => {
     if ((key.ctrl && (input === "c" || input === "C")) || input === "\u0003") {
-      // Ctrl+C pressed – treat as interrupt
-      if (onCtrlC) {
-        onCtrlC();
-      } else {
-        process.exit(0);
+      if (confirmExit()) {
+        if (onCtrlC) {
+          onCtrlC();
+        } else {
+          process.exit(0);
+        }
       }
     } else if (key.return) {
       if (value.trim() !== "") {

--- a/codex-cli/src/utils/terminal.ts
+++ b/codex-cli/src/utils/terminal.ts
@@ -82,3 +82,36 @@ export function onExit(): void {
     }
   }
 }
+
+// ---------------------------------------------------------------------------
+// Helper for Ctrl+C handling
+// ---------------------------------------------------------------------------
+
+let awaitingCtrlC = false;
+let awaitingTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Handle Ctrl+C keypresses. The first press prints a confirmation message and
+ * waits briefly for a second press. A second press within the confirmation
+ * window triggers a graceful shutdown.
+ *
+ * @returns `true` if the application should exit now, `false` otherwise.
+ */
+export function confirmExit(): boolean {
+  if (awaitingCtrlC) {
+    awaitingCtrlC = false;
+    if (awaitingTimer) {
+      clearTimeout(awaitingTimer);
+      awaitingTimer = null;
+    }
+    return true;
+  }
+
+  // eslint-disable-next-line no-console
+  console.error("Press Ctrl+C again to exit");
+  awaitingCtrlC = true;
+  awaitingTimer = setTimeout(() => {
+    awaitingCtrlC = false;
+  }, 1500);
+  return false;
+}

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -18,6 +18,7 @@ use crossterm::event::MouseEvent;
 use crossterm::event::MouseEventKind;
 use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
+use std::time::{Duration, Instant};
 use std::sync::mpsc::channel;
 
 /// Top-level application state: which full-screen view is currently active.
@@ -39,6 +40,7 @@ pub(crate) struct App<'a> {
     app_event_tx: AppEventSender,
     app_event_rx: Receiver<AppEvent>,
     app_state: AppState<'a>,
+    last_ctrl_c: Option<std::time::Instant>,
 
     /// Config is stored here so we can recreate ChatWidgets as needed.
     config: Config,
@@ -162,6 +164,7 @@ impl<'a> App<'a> {
             app_state,
             config,
             chat_args,
+            last_ctrl_c: None,
         }
     }
 
@@ -200,6 +203,10 @@ impl<'a> App<'a> {
                                 AppState::Login { .. } | AppState::GitWarning { .. } => {
                                     // No-op.
                                 }
+                            }
+
+                            if self.confirm_exit() {
+                                self.app_event_tx.send(AppEvent::ExitRequest);
                             }
                         }
                         KeyEvent {
@@ -320,5 +327,20 @@ impl<'a> App<'a> {
             AppState::Chat { widget } => widget.handle_codex_event(event),
             AppState::Login { .. } | AppState::GitWarning { .. } => {}
         }
+    }
+
+    /// Handle Ctrl+C presses. Returns `true` if the application should exit.
+    fn confirm_exit(&mut self) -> bool {
+        const TIMEOUT: Duration = Duration::from_millis(1500);
+        if let Some(last) = self.last_ctrl_c {
+            if last.elapsed() <= TIMEOUT {
+                self.last_ctrl_c = None;
+                return true;
+            }
+        }
+
+        self.last_ctrl_c = Some(Instant::now());
+        eprintln!("Press Ctrl+C again to exit");
+        false
     }
 }

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -267,7 +267,7 @@ impl ChatComposer<'_> {
 
         let bs = if has_focus {
             BlockState {
-                right_title: Line::from("Enter to send | Ctrl+D to quit | Ctrl+J for newline")
+                right_title: Line::from("Enter to send | Ctrl+C twice to quit | Ctrl+J for newline")
                     .alignment(Alignment::Right),
                 border_style: Style::default(),
             }


### PR DESCRIPTION
## Summary
- support double Ctrl+C to quit Codex CLI
- show confirmation message on first press
- update terminal hint text
- add helper `confirmExit`
- add same double Ctrl+C exit logic in Rust TUI

## Testing
- `pnpm run lint` *(fails: ESLint couldn't find a config file)*
- `pnpm run typecheck` *(fails: cannot find type definition file for 'node')*
- `cargo check -p codex-tui`
- `cargo test -p codex-tui`


------
https://chatgpt.com/codex/tasks/task_e_684aedef90c08328a8085813da230772